### PR TITLE
Upgrade to mini-mesos 0.5.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -127,8 +127,8 @@ subprojects {
         runtime "ch.qos.logback:logback-classic:${logbackVer}"
 
         testCompile "org.hamcrest:hamcrest-core:1.3"
-        testCompile "junit:junit-dep:${junitVer}"
-        testCompile "com.jayway.awaitility:awaitility:${awaitilityVer}"
+        compile "junit:junit-dep:${junitVer}"
+        compile "com.jayway.awaitility:awaitility:${awaitilityVer}"
         testCompile "org.mockito:mockito-all:${mockitoVer}"
     }
 

--- a/system-test/build.gradle
+++ b/system-test/build.gradle
@@ -2,10 +2,10 @@ dependencies {
     compile project(':logstash-commons')
     compile project(':logstash-scheduler')
 
-    compile 'com.github.docker-java:docker-java:1.3.0'
+    compile 'com.github.docker-java:docker-java:4f094c112'
     compile 'commons-lang:commons-lang:2.6'
     compile 'com.mashape.unirest:unirest-java:1.4.5'
-    compile 'com.github.ContainerSolutions:mini-mesos:9d8c635265'
+    compile 'com.github.ContainerSolutions:minimesos:0.5.0'
     compile 'org.elasticsearch:elasticsearch:1.7.3'
 }
 

--- a/system-test/src/test/java/org/apache/mesos/logstash/systemtest/AbstractLogstashFrameworkTest.java
+++ b/system-test/src/test/java/org/apache/mesos/logstash/systemtest/AbstractLogstashFrameworkTest.java
@@ -32,8 +32,9 @@ public abstract class AbstractLogstashFrameworkTest {
 
     private static final String DOCKER_PORT = "2376";
 
+    public static final int NUMBER_OF_SLAVES = 3;
     @ClassRule
-    public static MesosCluster cluster = new MesosCluster(ClusterUtil.withSlaves(3, zooKeeper -> new MesosSlave(null, zooKeeper) {
+    public static MesosCluster cluster = new MesosCluster(ClusterUtil.withSlaves(NUMBER_OF_SLAVES, zooKeeper -> new MesosSlave(null, zooKeeper) {
         @Override
         public TreeMap<String, String> getDefaultEnvVars() {
             final TreeMap<String, String> envVars = super.getDefaultEnvVars();
@@ -72,7 +73,7 @@ public abstract class AbstractLogstashFrameworkTest {
         configManager.start();
 
         System.out.println("**************** RECONCILIATION_DONE CONTAINERS ON TEST START *******************");
-        printRunningContainers();
+        printRunningContainers(clusterDockerClient);
         System.out.println("*********************************************************************");
 
         waitForLogstashFramework();
@@ -81,9 +82,7 @@ public abstract class AbstractLogstashFrameworkTest {
         executorContainer = new LogstashExecutorContainer(clusterDockerClient);
     }
 
-    private void printRunningContainers() {
-        DockerClient dockerClient = cluster.getConfig().dockerClient;
-
+    private void printRunningContainers(DockerClient dockerClient) {
         List<Container> containers = dockerClient.listContainersCmd().exec();
         for (Container container : containers) {
             System.out.println(container.getImage());
@@ -114,7 +113,7 @@ public abstract class AbstractLogstashFrameworkTest {
         Predicate<List<ExecutorMessage>> predicate) {
 
         int seconds = 10;
-        int numberOfExpectedMessages = cluster.getConfig().numberOfSlaves;
+        int numberOfExpectedMessages = NUMBER_OF_SLAVES;
 
         executorMessageListener.clearAllMessages();
 

--- a/system-test/src/test/java/org/apache/mesos/logstash/systemtest/DeploymentSystemTest.java
+++ b/system-test/src/test/java/org/apache/mesos/logstash/systemtest/DeploymentSystemTest.java
@@ -13,7 +13,6 @@ import com.github.dockerjava.api.command.CreateContainerCmd;
 import com.github.dockerjava.api.command.CreateContainerResponse;
 import com.github.dockerjava.api.model.Container;
 import com.github.dockerjava.api.model.Link;
-import com.github.dockerjava.core.command.PullImageResultCallback;
 import com.mashape.unirest.http.exceptions.UnirestException;
 import org.apache.commons.lang.RandomStringUtils;
 import org.apache.commons.lang.StringUtils;
@@ -95,7 +94,7 @@ public class DeploymentSystemTest {
         await().atMost(1, TimeUnit.MINUTES).pollInterval(1, TimeUnit.SECONDS).until(() -> {
             Framework framework = getClusterStateInfo().getFramework("logstash");
             assertNotNull(framework);
-            assertThat(framework.getTasks().size(), is(greaterThan(0)));
+            assertTrue(framework.getTasks().size() > 0);
             assertEquals("TASK_RUNNING", framework.getTasks().get(0).getState());
         });
     }
@@ -145,7 +144,7 @@ public class DeploymentSystemTest {
         final String sysLogPort = "514";
         final String randomLogLine = "Hello " + RandomStringUtils.randomAlphanumeric(32);
 
-        dockerClient.pullImageCmd("ubuntu:15.10").exec(new PullImageResultCallback());
+        dockerClient.pullImageCmd("ubuntu:15.10");
         final String logstashSlave = dockerClient.listContainersCmd().withSince(cluster.getSlaves()[0].getContainerId()).exec().stream().filter(container -> container.getImage().endsWith("/logstash-executor:latest")).findFirst().map(Container::getId).orElseThrow(() -> new RuntimeException("Unable to find logstash container"));
 
         await().atMost(1, TimeUnit.MINUTES).pollDelay(1, TimeUnit.SECONDS).until(() -> {

--- a/system-test/src/test/java/org/apache/mesos/logstash/systemtest/LocalCluster.java
+++ b/system-test/src/test/java/org/apache/mesos/logstash/systemtest/LocalCluster.java
@@ -2,7 +2,6 @@ package org.apache.mesos.logstash.systemtest;
 
 import com.containersol.minimesos.MesosCluster;
 import com.containersol.minimesos.mesos.ClusterUtil;
-import com.containersol.minimesos.mesos.MesosClusterConfig;
 import com.containersol.minimesos.mesos.MesosSlave;
 import com.github.dockerjava.api.DockerClient;
 import com.github.dockerjava.api.model.Container;
@@ -54,13 +53,11 @@ public class LocalCluster {
 
         while (!Thread.currentThread().isInterrupted()) {
             Thread.sleep(5000);
-            printRunningContainers();
+            printRunningContainers(clusterDockerClient);
         }
     }
 
-    private void printRunningContainers() {
-        DockerClient dockerClient = cluster.getConfig().dockerClient;
-
+    private void printRunningContainers(DockerClient dockerClient) {
         List<Container> containers = dockerClient.listContainersCmd().exec();
         for (Container container : containers) {
             System.out.println(container.getImage());

--- a/system-test/src/test/java/org/apache/mesos/logstash/systemtest/LogstashSystemTest.java
+++ b/system-test/src/test/java/org/apache/mesos/logstash/systemtest/LogstashSystemTest.java
@@ -65,7 +65,7 @@ public class LogstashSystemTest extends AbstractLogstashFrameworkTest {
 
         setConfigFor(HOST, "host", getFile("host.full.conf"));
 
-        new HostUtil(cluster.getMesosMasterContainer().getContainerId(), cluster.getConfig().dockerClient)
+        new HostUtil(cluster.getMesosMasterContainer().getContainerId(), clusterDockerClient)
                 .createFileWithContent("/tmp/testhost.log", logString);
 
         verifyLogstashProcessesLogEvents(SOME_LOGSTASH_OUTPUT_FILE, logString);


### PR DESCRIPTION
Had to upgrade docker java library version to match mini-mesos. I have asked why they are using a commit instead of a released version. Removed use of dockerClient in ClusterConfig. Main and System tests working on OSX.