### PR TITLE
Elasticsearch URL command-line option should actually be a URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ like this:
     --role='*' \
     --user=root \
     --logstash.heap-size=64 \
-    --logstash.elasticsearch-url=elasticsearch.service.consul:1234 \
+    --logstash.elasticsearch-url=http://elasticsearch.service.consul:1234 \
     --executor.cpus=0.5 \
     --executor.heap-size=128 \
     --enable.failover=false \
@@ -104,7 +104,7 @@ Here is the full list of configuration options:
 | `--mesos-principal=P`            | `MESOS_PRINCIPAL=P`            | Absent     | If present, the Logstash framework will authenticate with Mesos as principal `P`.                                          |
 | `--mesos-secret=S`               | `MESOS_SECRET=S`               | Absent     | If present, the Logstash framework will authenticate with Mesos using secret `S`.                                          |
 | `--logstash.heap-size=N`         | `LOGSTASH_HEAP_SIZE=N`         | `32`       | The Logstash program will be started with `LS_HEAP_SIZE=N` FIXME what does this actually do                                |
-| `--logstash.elasticsearch-url=U` | `LOGSTASH_ELASTICSEARCH_URL=U` | Absent     | If present, Logstash will forward its logs to an Elasticsearch instance at domain and port `U` FIXME this is not a URL!    |
+| `--logstash.elasticsearch-url=U` | `LOGSTASH_ELASTICSEARCH_URL=U` | Absent     | If present, Logstash will forward its logs to an Elasticsearch instance at `U`                                             |
 | `--executor.cpus=C`              | `EXECUTOR_CPUS=C`              | `0.2`      | The Logstash framework will only accept resource offers with at least `C` CPUs. `C` must be a decimal greater than 0       |
 | `--executor.heap-size=H`         | `EXECUTOR_HEAP_SIZE=H`         | `64`       | The memory allocation pool for the Logstash executor will be limited to `H` megabytes                                      |
 | `--enable.failover=B`            | `ENABLE_FAILOVER=B`            | `true`     | Iff `B` is `true`, all executors and tasks will remain running after this scheduler exits FIXME what's the format for `B`? |

--- a/logstash-commons/src/main/proto/logstash.proto
+++ b/logstash-commons/src/main/proto/logstash.proto
@@ -37,7 +37,8 @@ message LogstashPluginInputFile {
 
 // Corresponds to a https://www.elastic.co/guide/en/logstash/current/plugins-outputs-elasticsearch.html
 message LogstashPluginOutputElasticsearch {
-  required string host = 1;
+  required string url = 1;
+  optional string index = 2;
 }
 
 message SchedulerMessage {

--- a/logstash-executor/src/main/java/org/apache/mesos/logstash/executor/LogstashService.java
+++ b/logstash-executor/src/main/java/org/apache/mesos/logstash/executor/LogstashService.java
@@ -1,6 +1,7 @@
 package org.apache.mesos.logstash.executor;
 
 import org.apache.commons.compress.utils.IOUtils;
+import org.apache.commons.lang.StringUtils;
 import org.apache.mesos.logstash.common.LogstashProtos;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -9,10 +10,14 @@ import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.lang.reflect.Array;
+import java.net.MalformedURLException;
+import java.net.URL;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.Consumer;
+import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
 /**
@@ -22,11 +27,22 @@ public class LogstashService {
 
     public static final Logger LOGGER = LoggerFactory.getLogger(LogstashService.class);
 
+    private static <T> Optional<T> ofConditional(T message, Predicate<T> predicate) {
+        if (message != null && predicate.test(message)) {
+            return Optional.of(message);
+        }
+        return Optional.empty();
+    }
+
     private static String serialize(LogstashProtos.LogstashConfiguration logstashConfiguration) {
+        LOGGER.info("Received " + logstashConfiguration.toString());
+        LOGGER.info("logstashConfiguration.getLogstashPluginOutputElasticsearch() = " + logstashConfiguration.getLogstashPluginOutputElasticsearch().isInitialized());
+
+
         List<LS.Plugin> inputPlugins = optionalValuesToList(
-                Optional.ofNullable(logstashConfiguration.getLogstashPluginInputSyslog()).map(config -> LS.plugin("syslog", LS.map(LS.kv("port", LS.number(config.getPort()))))),
-                Optional.ofNullable(logstashConfiguration.getLogstashPluginInputCollectd()).map(config -> LS.plugin("udp", LS.map(LS.kv("port", LS.number(5000 /*TODO: config.getPort()*/)), LS.kv("buffer_size", LS.number(1452)), LS.kv("codec", LS.plugin("collectd", LS.map()))))),
-                Optional.ofNullable(logstashConfiguration.getLogstashPluginInputFile()).map(config -> LS.plugin("file", LS.map(LS.kv("path", LS.array(config.getPathList().stream().map(path -> "/logstashpaths" + path).map(LS::string).toArray(LS.Value[]::new))))))
+                ofConditional(logstashConfiguration.getLogstashPluginInputSyslog(), LogstashProtos.LogstashPluginInputSyslog::isInitialized).map(config -> LS.plugin("syslog", LS.map(LS.kv("port", LS.number(config.getPort()))))),
+                ofConditional(logstashConfiguration.getLogstashPluginInputCollectd(), LogstashProtos.LogstashPluginInputCollectd::isInitialized).map(config -> LS.plugin("udp", LS.map(LS.kv("port", LS.number(5000 /*TODO: config.getPort()*/)), LS.kv("buffer_size", LS.number(1452)), LS.kv("codec", LS.plugin("collectd", LS.map()))))),
+                ofConditional(logstashConfiguration.getLogstashPluginInputFile(), LogstashProtos.LogstashPluginInputFile::isInitialized).map(config -> LS.plugin("file", LS.map(LS.kv("path", LS.array(config.getPathList().stream().map(path -> "/logstashpaths" + path).map(LS::string).toArray(LS.Value[]::new))))))
         );
 
         List<LS.Plugin> filterPlugins = Arrays.asList(
@@ -40,14 +56,26 @@ public class LogstashService {
         );
 
         List<LS.Plugin> outputPlugins = optionalValuesToList(
-                Optional.ofNullable(logstashConfiguration.getLogstashPluginOutputElasticsearch()).map(config -> LS.plugin(
-                        "elasticsearch",
-                        LS.map(
-                                LS.kv("host", LS.string(config.getHost())),
-                                LS.kv("protocol", LS.string("http")),
-                                LS.kv("index", LS.string("logstash"))  //FIXME this should be configurable. Maybe add -%{+YYYY.MM.dd}
-                        )
-                ))
+                ofConditional(logstashConfiguration.getLogstashPluginOutputElasticsearch(), LogstashProtos.LogstashPluginOutputElasticsearch::isInitialized).map(config -> {
+                    URL url;
+                    try {
+                        url = new URL(config.getUrl());
+                    } catch (MalformedURLException e) {
+                        throw new RuntimeException("Failed to parse Elasticsearch URL: " + config.getUrl(), e);
+                    }
+                    return LS.plugin(
+                            "elasticsearch",
+                            LS.map(
+                                    filterEmpties(
+                                            LS.KV.class,
+                                            Optional.of(LS.kv("host", LS.string(url.getHost()))),
+                                            Optional.of(LS.kv("port", LS.number(url.getPort() > 0 ? url.getPort() : 9200))),
+                                            Optional.of(LS.kv("protocol", LS.string(url.getProtocol()))),
+                                            ofConditional(config.getIndex(), StringUtils::isNotEmpty).map(index -> LS.kv("index", LS.string(index)))
+                                    )
+                            )
+                    );
+                })
         );
 
         return LS.config(
@@ -55,6 +83,10 @@ public class LogstashService {
                 LS.section("filter", filterPlugins.toArray(new LS.Plugin[filterPlugins.size()])),
                 LS.section("output", outputPlugins.toArray(new LS.Plugin[outputPlugins.size()]))
         ).serialize();
+    }
+
+    private static <T> T[] filterEmpties(Class<T> type, Optional<T>... optionals) {
+        return Arrays.stream(optionals).filter(Optional::isPresent).map(Optional::get).toArray(size -> (T[]) Array.newInstance(type, size));
     }
 
     @SafeVarargs

--- a/logstash-scheduler/src/main/java/org/apache/mesos/logstash/config/LogstashConfig.java
+++ b/logstash-scheduler/src/main/java/org/apache/mesos/logstash/config/LogstashConfig.java
@@ -3,13 +3,14 @@ package org.apache.mesos.logstash.config;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.stereotype.Component;
 
+import java.net.URL;
 import java.util.Optional;
 
 @Component
 @ConfigurationProperties(prefix = "logstash")
 public class LogstashConfig {
     private int heapSize = 64;
-    private Optional<String> elasticsearchUrl = Optional.empty();
+    private Optional<URL> elasticsearchUrl = Optional.empty();
 
     public int getHeapSize() {
         return heapSize;
@@ -19,11 +20,11 @@ public class LogstashConfig {
         this.heapSize = heapSize;
     }
 
-    public Optional<String> getElasticsearchUrl() {
+    public Optional<URL> getElasticsearchUrl() {
         return elasticsearchUrl;
     }
 
-    public void setElasticsearchUrl(Optional<String> elasticsearchUrl) {
+    public void setElasticsearchUrl(Optional<URL> elasticsearchUrl) {
         this.elasticsearchUrl = elasticsearchUrl;
     }
 }

--- a/logstash-scheduler/src/main/java/org/apache/mesos/logstash/scheduler/LogstashScheduler.java
+++ b/logstash-scheduler/src/main/java/org/apache/mesos/logstash/scheduler/LogstashScheduler.java
@@ -69,9 +69,6 @@ public class LogstashScheduler implements org.apache.mesos.Scheduler {
 
         LOGGER.info("Starting Logstash Framework: \n{}", frameworkBuilder);
 
-        driver = mesosSchedulerDriverFactory.createMesosDriver(this, frameworkBuilder.build(),
-            frameworkConfig.getZkUrl());
-        
         if (frameworkConfig.getMesosPrincipal() != null) {
             Protos.Credential.Builder credentialBuilder = Protos.Credential.newBuilder();
             frameworkBuilder.setPrincipal(frameworkConfig.getMesosPrincipal());

--- a/logstash-scheduler/src/main/java/org/apache/mesos/logstash/scheduler/TaskInfoBuilder.java
+++ b/logstash-scheduler/src/main/java/org/apache/mesos/logstash/scheduler/TaskInfoBuilder.java
@@ -73,7 +73,7 @@ public class TaskInfoBuilder {
             );
         }
         //TODO: repeat for collectd
-        logstashConfig.getElasticsearchUrl().ifPresent(hostAndPort -> logstashConfigBuilder.setLogstashPluginOutputElasticsearch(LogstashProtos.LogstashPluginOutputElasticsearch.newBuilder().setHost(hostAndPort)));
+        logstashConfig.getElasticsearchUrl().ifPresent(url -> logstashConfigBuilder.setLogstashPluginOutputElasticsearch(LogstashProtos.LogstashPluginOutputElasticsearch.newBuilder().setUrl(url.toExternalForm())));
 
         logstashConfigBuilder.setMesosSlaveId(offer.getSlaveId().getValue());
 
@@ -82,8 +82,6 @@ public class TaskInfoBuilder {
                     LogstashProtos.LogstashPluginInputFile.newBuilder().addAllPath(executorConfig.getFilePath())
             );
         }
-
-        LogstashProtos.LogstashConfiguration logstashConfiguration = logstashConfigBuilder.build();
 
 
         return Protos.TaskInfo.newBuilder()

--- a/system-test/src/main/java/org/apache/mesos/logstash/systemtest/LogstashSchedulerContainer.java
+++ b/system-test/src/main/java/org/apache/mesos/logstash/systemtest/LogstashSchedulerContainer.java
@@ -26,7 +26,7 @@ public class LogstashSchedulerContainer extends AbstractContainer {
 
     private String zookeeperIpAddress;
     private final int apiPort = 9092;
-    private Optional<String> elasticsearchDomainAndPort = Optional.empty();
+    private Optional<String> elasticsearchUrl = Optional.empty();
     private boolean withSyslog = false;
 
     public LogstashSchedulerContainer(DockerClient dockerClient, String zookeeperIpAddress) {
@@ -34,10 +34,10 @@ public class LogstashSchedulerContainer extends AbstractContainer {
         this.zookeeperIpAddress = zookeeperIpAddress;
     }
 
-    public LogstashSchedulerContainer(DockerClient dockerClient, String zookeeperIpAddress, String elasticsearchDomainAndPort) {
+    public LogstashSchedulerContainer(DockerClient dockerClient, String zookeeperIpAddress, String elasticsearchUrl) {
         super(dockerClient);
         this.zookeeperIpAddress = zookeeperIpAddress;
-        this.elasticsearchDomainAndPort = Optional.ofNullable(elasticsearchDomainAndPort);
+        this.elasticsearchUrl = Optional.ofNullable(elasticsearchUrl);
     }
 
     private List<String> getJavaOpts() {
@@ -46,7 +46,7 @@ public class LogstashSchedulerContainer extends AbstractContainer {
                         "-Dmesos.logstash.framework.name=logstash",
                         "-Dmesos.logstash.volumes=/var/log/mesos"
                 ),
-                elasticsearchDomainAndPort.map(d -> "-Dmesos.logstash.elasticsearchDomainAndPort=" + d)
+                elasticsearchUrl.map(d -> "-Dmesos.logstash.elasticsearchDomainAndPort=" + d)
         );
     }
 
@@ -68,7 +68,7 @@ public class LogstashSchedulerContainer extends AbstractContainer {
         final String cmd = asList(
                 "--zk-url=zk://" + zookeeperIpAddress + ":2181/mesos",
                 "--failover-enabled=false",
-                elasticsearchDomainAndPort.map(url -> "--logstash.elasticsearch-url=" + url).orElse(null),
+                elasticsearchUrl.map(url -> "--logstash.elasticsearch-url=" + url).orElse(null),
                 "--executor.heap-size=64",
                 "--logstash.heap-size=128",
                 withSyslog ? "--enable.syslog=true" : null


### PR DESCRIPTION
Currently `--logstash.elasticsearch-url` accepts a domain:port, but it should accept a full URL