### PR TITLE
Scheduler fails to register as framework if logstash role isn't defined

### DIFF
--- a/logstash-scheduler/src/main/java/org/apache/mesos/logstash/config/FrameworkConfig.java
+++ b/logstash-scheduler/src/main/java/org/apache/mesos/logstash/config/FrameworkConfig.java
@@ -20,7 +20,7 @@ public class FrameworkConfig {
     private double failoverTimeout = 31449600;
     private long reconcilationTimeoutMillis;
 
-    private String mesosRole = "logstash";
+    private String mesosRole = "*";
     private String mesosUser = "root";
 
     private String mesosPrincipal = null;

--- a/logstash-scheduler/src/test/java/org/apache/mesos/logstash/scheduler/LogstashSchedulerTest.java
+++ b/logstash-scheduler/src/test/java/org/apache/mesos/logstash/scheduler/LogstashSchedulerTest.java
@@ -71,7 +71,7 @@ public class LogstashSchedulerTest {
         Protos.FrameworkInfo frameworkInfo = frameworkInfoArgumentCaptor.getValue();
         assertEquals(frameworkInfo.getName(), frameworkConfig.getFrameworkName());
         assertEquals("root", frameworkInfo.getUser());
-        assertEquals("logstash", frameworkInfo.getRole());
+        assertEquals("*", frameworkInfo.getRole());
         assertEquals(frameworkInfo.hasCheckpoint(), true);
         assertEquals((int)frameworkInfo.getFailoverTimeout(),(int) frameworkConfig.getFailoverTimeout());
         assertEquals(frameworkInfo.getId().getValue(), frameworkState.getFrameworkID().getValue());

--- a/logstash-scheduler/src/test/java/org/apache/mesos/logstash/scheduler/OfferStrategyTest.java
+++ b/logstash-scheduler/src/test/java/org/apache/mesos/logstash/scheduler/OfferStrategyTest.java
@@ -11,10 +11,10 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 
+import java.util.Optional;
+
 import static java.util.Collections.singletonList;
-import static org.apache.mesos.logstash.scheduler.Resources.cpus;
-import static org.apache.mesos.logstash.scheduler.Resources.mem;
-import static org.apache.mesos.logstash.scheduler.Resources.portRange;
+import static org.apache.mesos.logstash.scheduler.Resources.*;
 import static org.junit.Assert.*;
 import static org.mockito.Mockito.when;
 
@@ -98,6 +98,24 @@ public class OfferStrategyTest {
                         .build());
         assertTrue(result.acceptable);
         assertFalse(result.reason.isPresent());
+    }
+
+    @Test
+    public void willAcceptValidOfferFromCommonPool() throws Exception {
+        when(clusterState.getTaskList()).thenReturn(singletonList(createTask("host1")));
+        when(features.isSyslog()).thenReturn(true);
+        when(logstashConfig.getSyslogPort()).thenReturn(514);
+        when(features.isCollectd()).thenReturn(false);
+
+        final OfferStrategy.OfferResult result = offerStrategy.evaluate(
+                clusterState,
+                baseOfferBuilder("host2")
+                        .addResources(cpus(1.0, "*"))
+                        .addResources(mem(512, "*"))
+                        .addResources(portRange(514, 514, "*"))
+                        .build());
+        assertEquals(Optional.empty(), result.reason);
+        assertTrue(result.acceptable);
     }
 
     @Test

--- a/system-test/src/main/java/org/apache/mesos/logstash/systemtest/LogstashSchedulerContainer.java
+++ b/system-test/src/main/java/org/apache/mesos/logstash/systemtest/LogstashSchedulerContainer.java
@@ -28,15 +28,12 @@ public class LogstashSchedulerContainer extends AbstractContainer {
     private final int apiPort = 9092;
     private Optional<String> elasticsearchUrl = Optional.empty();
     private boolean withSyslog = false;
+    private final Optional<String> mesosRole;
 
-    public LogstashSchedulerContainer(DockerClient dockerClient, String zookeeperIpAddress) {
+    public LogstashSchedulerContainer(DockerClient dockerClient, String zookeeperIpAddress, String mesosRole, String elasticsearchUrl) {
         super(dockerClient);
         this.zookeeperIpAddress = zookeeperIpAddress;
-    }
-
-    public LogstashSchedulerContainer(DockerClient dockerClient, String zookeeperIpAddress, String elasticsearchUrl) {
-        super(dockerClient);
-        this.zookeeperIpAddress = zookeeperIpAddress;
+        this.mesosRole = Optional.ofNullable(mesosRole);
         this.elasticsearchUrl = Optional.ofNullable(elasticsearchUrl);
     }
 
@@ -67,6 +64,7 @@ public class LogstashSchedulerContainer extends AbstractContainer {
     protected CreateContainerCmd dockerCommand() {
         final String cmd = asList(
                 "--zk-url=zk://" + zookeeperIpAddress + ":2181/mesos",
+                mesosRole.map(role -> "--mesos-role=" + role).orElse(null),
                 "--failover-enabled=false",
                 elasticsearchUrl.map(url -> "--logstash.elasticsearch-url=" + url).orElse(null),
                 "--executor.heap-size=64",

--- a/system-test/src/test/java/org/apache/mesos/logstash/systemtest/AbstractLogstashFrameworkTest.java
+++ b/system-test/src/test/java/org/apache/mesos/logstash/systemtest/AbstractLogstashFrameworkTest.java
@@ -54,7 +54,7 @@ public abstract class AbstractLogstashFrameworkTest {
                 .withUri("http://" + cluster.getMesosMasterContainer().getIpAddress() + ":" + DOCKER_PORT);
         clusterDockerClient = DockerClientBuilder.getInstance(dockerConfigBuilder.build()).build();
 
-        LogstashSchedulerContainer schedulerContainer = new LogstashSchedulerContainer(clusterDockerClient, cluster.getMesosMasterContainer().getIpAddress());
+        LogstashSchedulerContainer schedulerContainer = new LogstashSchedulerContainer(clusterDockerClient, cluster.getMesosMasterContainer().getIpAddress(), null, null);
         schedulerContainer.start();
     }
 

--- a/system-test/src/test/java/org/apache/mesos/logstash/systemtest/DeploymentSystemTest.java
+++ b/system-test/src/test/java/org/apache/mesos/logstash/systemtest/DeploymentSystemTest.java
@@ -85,7 +85,7 @@ public class DeploymentSystemTest {
     @Test
     public void testDeployment() throws JsonParseException, UnirestException, JsonMappingException {
         String zookeeperIpAddress = cluster.getZkContainer().getIpAddress();
-        scheduler = Optional.of(new LogstashSchedulerContainer(dockerClient, zookeeperIpAddress));
+        scheduler = Optional.of(new LogstashSchedulerContainer(dockerClient, zookeeperIpAddress, null, null));
         cluster.addAndStartContainer(scheduler.get());
 
         waitForFramework();
@@ -136,7 +136,7 @@ public class DeploymentSystemTest {
         });
         assertEquals(elasticsearchClusterName, elasticsearchClient.get().admin().cluster().health(Requests.clusterHealthRequest("_all")).actionGet().getClusterName());
 
-        scheduler = Optional.of(new LogstashSchedulerContainer(dockerClient, zookeeperIpAddress, "http://" + elasticsearchInstance.getIpAddress() + ":" + 9200));
+        scheduler = Optional.of(new LogstashSchedulerContainer(dockerClient, zookeeperIpAddress, "logstash", "http://" + elasticsearchInstance.getIpAddress() + ":" + 9200));
         scheduler.get().enableSyslog();
         cluster.addAndStartContainer(scheduler.get());
 
@@ -189,7 +189,7 @@ public class DeploymentSystemTest {
     @Test
     public void willAddExecutorOnNewNodes() throws JsonParseException, UnirestException, JsonMappingException {
         String zookeeperIpAddress = cluster.getZkContainer().getIpAddress();
-        scheduler = Optional.of(new LogstashSchedulerContainer(dockerClient, zookeeperIpAddress));
+        scheduler = Optional.of(new LogstashSchedulerContainer(dockerClient, zookeeperIpAddress, null, null));
         cluster.addAndStartContainer(scheduler.get());
 
         waitForFramework();


### PR DESCRIPTION
On minimal configuration, with only file input enabled, the scheduler fails to register the framework