### PR TITLE
Logstash framework uses 8080 port (file server)

### DIFF
--- a/logstash-scheduler/src/main/java/org/apache/mesos/logstash/config/FrameworkConfig.java
+++ b/logstash-scheduler/src/main/java/org/apache/mesos/logstash/config/FrameworkConfig.java
@@ -1,7 +1,10 @@
 package org.apache.mesos.logstash.config;
 
 import org.apache.mesos.logstash.common.network.NetworkUtils;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.context.embedded.EmbeddedServletContainerInitializedEvent;
 import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.ApplicationListener;
 import org.springframework.stereotype.Component;
 
 import javax.inject.Inject;
@@ -10,8 +13,7 @@ import javax.inject.Inject;
 
 @Component
 @ConfigurationProperties
-public class FrameworkConfig {
-
+public class FrameworkConfig implements ApplicationListener<EmbeddedServletContainerInitializedEvent> {
     private static final String LOGSTASH_EXECUTOR_JAR   = "logstash-mesos-executor.jar";
 
     private static final String LOGSTASH_TARBALL = "logstash.tar.gz";
@@ -20,6 +22,13 @@ public class FrameworkConfig {
 
     @Inject
     private NetworkUtils networkUtils;
+
+    int httpPort;
+
+    @Override
+    public void onApplicationEvent(EmbeddedServletContainerInitializedEvent event) {
+        httpPort = event.getEmbeddedServletContainer().getPort();
+    }
 
     public String getJavaHome() {
         if (!javaHome.isEmpty()) {
@@ -34,7 +43,7 @@ public class FrameworkConfig {
     }
 
     public String getFrameworkFileServerAddress() {
-        return networkUtils.addressToString(networkUtils.hostSocket(8080), true);
+        return networkUtils.addressToString(networkUtils.hostSocket(httpPort), true);
     }
 
     public String getLogstashTarballUri() {


### PR DESCRIPTION
https://github.com/mesos/logstash/blob/master/logstash-scheduler/src/main/java/org/apache/mesos/logstash/config/FrameworkConfig.java#L37

we are running logstash without docker on mesos+marathon.
when mesos tries to start logstash framework on any host, which has marathon running - logstash fails, because it tries to use 8080 port, which is already taken (by marathon).

**example:** marathons tells that logstash framework is running on 6053 port of slave-07:
```
[cloud-user@slave-07 ~]$ curl master-01:8080/v2/apps/logstash/ | jq .app.tasks
[
  {
    "id": "logstash.1f57736f-eaab-11e5-9fe4-0242cccd6336",
    "host": "slave-07.test.com",
    "ports": [
      6053
    ],
```
but there is nothing there:
```
[cloud-user@slave-07 ~]$ sudo netstat -tuplan | grep 6053
[cloud-user@slave-07 ~]$
```

while logstash framework is running on 8080 port.
```
[cloud-user@slave-07 ~]$ sudo netstat -tuplan | grep 8080
tcp6       0      0 :::8080                 :::*                    LISTEN      7620/java
[cloud-user@slave-07 ~]$ sudo ps waxu | grep 7620
root      7620  2.3  3.4 9247916 731364 ?      Ssl  12:40   0:14 java -jar logstash-mesos-scheduler.jar
```